### PR TITLE
add colored syntax highlighting to 2012-10-06-gsoc2012-status9 post

### DIFF
--- a/_posts/blog/2012-10-06-gsoc2012-status9.md
+++ b/_posts/blog/2012-10-06-gsoc2012-status9.md
@@ -67,7 +67,7 @@ This feature can be used to produce labels for e.g. borders.
 ### Syntax
 
 {% highlight xml %}
-<TextSymbolizer dy="10" ...>[name]</TextSymbolizer>```
+<TextSymbolizer dy="10" ...>[name]</TextSymbolizer>
 {% endhighlight %}
 
 

--- a/_posts/blog/2012-10-06-gsoc2012-status9.md
+++ b/_posts/blog/2012-10-06-gsoc2012-status9.md
@@ -52,7 +52,7 @@ time.
 ### Syntax
 
 {% highlight xml %}
-<TextSymbolizer wrap-width="100" ...>[name]</TextSymbolizer>
+<TextSymbolizer wrap-width="100" >[name]</TextSymbolizer>
 {% endhighlight %}
 
 ## Correct offsets
@@ -67,7 +67,7 @@ This feature can be used to produce labels for e.g. borders.
 ### Syntax
 
 {% highlight xml %}
-<TextSymbolizer dy="10" ...>[name]</TextSymbolizer>
+<TextSymbolizer dy="10" >[name]</TextSymbolizer>
 {% endhighlight %}
 
 
@@ -86,9 +86,9 @@ parameter "upright" was added to TextSymbolizer to choose the desired function.
 ### Syntax
 
 {% highlight xml %}
-<TextSymbolizer upright="auto" ...>[name]</TextSymbolizer>
-<TextSymbolizer upright="left" ...>[name]</TextSymbolizer>
-<TextSymbolizer upright="right" ...>[name]</TextSymbolizer>
+<TextSymbolizer upright="auto" >[name]</TextSymbolizer>
+<TextSymbolizer upright="left" >[name]</TextSymbolizer>
+<TextSymbolizer upright="right" >[name]</TextSymbolizer>
 {% endhighlight %}
 
 
@@ -109,7 +109,7 @@ Rotate displacement: On
 ![rotate displacement on](/images/harfbuzz/rotate_displacement_on.png)
 ### Syntax
 {% highlight xml %}
-<TextSymbolizer dx="5" rotate-displacement="true" ...>[name]</TextSymbolizer>
+<TextSymbolizer dx="5" rotate-displacement="true" >[name]</TextSymbolizer>
 {% endhighlight %}
 
 
@@ -199,7 +199,7 @@ Labeling multiple bus routes at the same bus stop:
 ### Syntax
 
 {% highlight xml %}
-    <ShieldSymbolizer [...] placement-type="list" horizontal-alignment="middle" vertical-alignment="middle">[ref]
+    <ShieldSymbolizer placement-type="list" horizontal-alignment="middle" vertical-alignment="middle">[ref]
     <Placement dx="50"/>
     <Placement dx="100"/>
     <Placement dx="0" dy="35"/>

--- a/_posts/blog/2012-10-06-gsoc2012-status9.md
+++ b/_posts/blog/2012-10-06-gsoc2012-status9.md
@@ -51,10 +51,9 @@ time.
 ![Multiline street labels](/images/harfbuzz/multiline-streets.png)
 ### Syntax
 
-```
+{% highlight xml %}
 <TextSymbolizer wrap-width="100" ...>[name]</TextSymbolizer>
-```
-
+{% endhighlight %}
 
 ## Correct offsets
 Mapnik already supported offsetting text on lines, but the algorithm was very
@@ -66,7 +65,10 @@ This feature can be used to produce labels for e.g. borders.
 ### Example image
 ![Country labels](/images/harfbuzz/countries.png)
 ### Syntax
-```<TextSymbolizer dy="10" ...>[name]</TextSymbolizer>```
+
+{% highlight xml %}
+<TextSymbolizer dy="10" ...>[name]</TextSymbolizer>```
+{% endhighlight %}
 
 
 ## Upright
@@ -82,9 +84,12 @@ parameter "upright" was added to TextSymbolizer to choose the desired function.
 ### Example image
 ![contour lines](/images/harfbuzz/contour.png)
 ### Syntax
-```<TextSymbolizer upright="auto" ...>[name]</TextSymbolizer>
+
+{% highlight xml %}
+<TextSymbolizer upright="auto" ...>[name]</TextSymbolizer>
 <TextSymbolizer upright="left" ...>[name]</TextSymbolizer>
-<TextSymbolizer upright="right" ...>[name]</TextSymbolizer>```
+<TextSymbolizer upright="right" ...>[name]</TextSymbolizer>
+{% endhighlight %}
 
 
 # Rotate displacement
@@ -103,7 +108,10 @@ Rotate displacement: Off (default)
 Rotate displacement: On
 ![rotate displacement on](/images/harfbuzz/rotate_displacement_on.png)
 ### Syntax
-```<TextSymbolizer dx="5" rotate-displacement="true" ...>[name]</TextSymbolizer>```
+{% highlight xml %}
+<TextSymbolizer dx="5" rotate-displacement="true" ...>[name]</TextSymbolizer>
+{% endhighlight %}
+
 
 # Kerning & Ligatures
 [Kerning](http://en.wikipedia.org/wiki/Kerning) and
@@ -160,11 +168,19 @@ This feature can be used for better labeling of highways with multiple names.
 ### Example image
 ![multiple shields](/images/harfbuzz/multiple-shields.png)
 ### Syntax
-```<ShieldSymbolizer label-position-tolerance="100">[ref]</ShieldSymbolizer>```
+
+
+{% highlight xml %}
+<ShieldSymbolizer label-position-tolerance="100">[ref]</ShieldSymbolizer>
+{% endhighlight %}
+
 
 or automatically enabled for Symbolizers with non-zero `spacing`:
 
-```<ShieldSymbolizer spacing="200">[ref]</ShieldSymbolizer>```
+{% highlight xml %}
+<ShieldSymbolizer spacing="200">[ref]</ShieldSymbolizer>
+{% endhighlight %}
+
 
 
 ## Alternate positions
@@ -181,6 +197,8 @@ get the desired effect in most cases.)
 Labeling multiple bus routes at the same bus stop:
 ![bus routes](/images/harfbuzz/busstop.png)
 ### Syntax
+
+{% highlight xml %}
     <ShieldSymbolizer [...] placement-type="list" horizontal-alignment="middle" vertical-alignment="middle">[ref]
     <Placement dx="50"/>
     <Placement dx="100"/>
@@ -188,6 +206,8 @@ Labeling multiple bus routes at the same bus stop:
     <Placement dx="50" />
     <Placement dx="100"/>
     </ShieldSymbolizer>
+{% endhighlight %}
+
 This syntax is not optimal but an placement algorithm supporting grid placements
 will be added some time.
 
@@ -195,22 +215,21 @@ will be added some time.
 # Installation
 
 Download and install harfbuzz:
-    wget http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-0.9.4.tar.bz2
-    tar -xjf harfbuzz-0.9.4.tar.bz2
-    cd harfbuzz-0.9.4/
-    ./configure "ICU_CFLAGS=`icu-config --cflags`" "ICU_LIBS=`icu-config --ldflags`"
-    make
-and as root
-    make install
+
+{% highlight bash %}
+wget http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-0.9.4.tar.bz2
+tar -xjf harfbuzz-0.9.4.tar.bz2
+cd harfbuzz-0.9.4/
+./configure "ICU_CFLAGS=`icu-config --cflags`" "ICU_LIBS=`icu-config --ldflags`"
+make
+make install
+{% endhighlight %}
 
 Download and install mapnik
-    git clone -b harfbuzz --depth 1 git://github.com/mapnik/mapnik.git mapnik-harfbuzz
-    cd mapnik-harfbuzz
-    ./configure
-    make
-and as root
-    make install # Warning this overwrites previous mapnik installations!
 
-
-
-
+{% highlight bash %}
+git clone -b harfbuzz --depth 1 git://github.com/mapnik/mapnik.git mapnik-harfbuzz
+cd mapnik-harfbuzz
+./configure
+make
+{% endhighlight %}


### PR DESCRIPTION
This switches out backtickts for `{% highlight xml %}` and `{% endhighlight %}`.

Just tried this out for one oldish post. @amyleew - is this the right/recommended approach? Not worried about updating all the old posts, just want to confirm this is the right way going forward.

![screen shot 2015-06-11 at 9 18 57 am](https://cloud.githubusercontent.com/assets/20300/8112159/eb1bbde8-101a-11e5-8b22-2be5ca29b388.png)
