### PR TITLE
Downloads page added to footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,3 +1,3 @@
 <div class='content col12 center caption small fill-sea dark pad1y'>
-	Copyright © 2015 Artem Pavlenko  |  <a href='{{sitebase.url}}/pages/license.html'>License</a>  |  <a href='{{sitebase.url}}/pages/media.html'>Media</a>
+	Copyright © 2015 Artem Pavlenko  |  <a href='{{sitebase.url}}/pages/downloads.md'>Downloads</a>  | <a href='{{sitebase.url}}/pages/license.html'>License</a>  |  <a href='{{sitebase.url}}/pages/media.html'>Media</a>
 </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,3 +1,3 @@
 <div class='content col12 center caption small fill-sea dark pad1y'>
-	Copyright © 2015 Artem Pavlenko  |  <a href='{{sitebase.url}}/pages/downloads.md'>Downloads</a>  | <a href='{{sitebase.url}}/pages/license.html'>License</a>  |  <a href='{{sitebase.url}}/pages/media.html'>Media</a>
+	Copyright © 2015 Artem Pavlenko  |  <a href='{{sitebase.url}}/pages/downloads.html'>Downloads</a>  | <a href='{{sitebase.url}}/pages/license.html'>License</a>  |  <a href='{{sitebase.url}}/pages/media.html'>Media</a>
 </div>

--- a/_layouts/01_splash.html
+++ b/_layouts/01_splash.html
@@ -16,6 +16,10 @@
 				<div id='tagline' class='col5 space-top4 dark pad4y prose fr'>the core of geospatial visualization &amp; processing</div>
 			</div>
 			<div id='intro' class='col9 margin2 pad2y dark big'>mapnik combines pixel-perfect image output with lightning-fast cartographic algorithms, and exposes interfaces in C++, Python, and Node.</div>
+			<div id='intro' class='col9 margin2 pad2y dark big'>
+				<a href='{{site.baseurl}}/pages/downloads.html' class='button stroke white col5'>Download mapnik</a>
+			</div>
+
 		</div>
 		<!-- map design -->
 		<div class='module pad8y'></div>

--- a/css/mapnik.css
+++ b/css/mapnik.css
@@ -124,7 +124,7 @@ hr.sm {
 /* background */
 
 .gradient {
-  height: 450px;
+  height: 500px;
   padding-bottom: 30px;
   background-color: white;
   background-image:
@@ -405,14 +405,18 @@ h1.fancy {
   }
 }
 
+@media only screen and (max-width: 800px) {
+  #intro.big {
+	font-size: 30px;
+    line-height: 40px;
+  }
+}
+
 @media only screen and (max-width: 640px) {
   #navbar .pad4y {
   padding-top: 10px;
   padding-bottom: 10px;
   }
-}
-
-@media only screen and (max-width: 640px) {
   #mapnik .splash { text-size: 12; } 
   #logo.pad4y {
   	padding-top: 10px;
@@ -429,11 +433,6 @@ h1.fancy {
 	font-size: 32px;
     line-height: 45px;
   }
-}
-
-
-@media only screen and (max-width: 640px) {
-
   .toc {
     border: 1px solid rgba(0,0,0,0.10);
     margin-bottom: 20px;
@@ -1006,6 +1005,21 @@ a.quiet.dark.active, a.quiet.dark:hover { color:rgba(255,255,255,0.5); }
   background-color: transparent;
   box-shadow: 0px 0px 0px 2px rgba(255,255,255,.5) inset;
   color: rgba(255,255,255,.75);
+}
+
+.dark .button.white {
+  border: none;
+  box-shadow: 0px 0px 0px 2px white inset;
+  color: white;
+  text-transform:uppercase;
+  letter-spacing: 2;
+  font-size: 14px;
+}
+
+.dark .button.white:hover,
+.dark .button.white.active {
+  color: rgb(86, 181, 190);
+  background-color: white;
 }
 
 .dark .button.stroke.quiet {

--- a/pages/downloads.md
+++ b/pages/downloads.md
@@ -1,6 +1,6 @@
 ---
 layout: 01_page
-title: Download
+title: Downloads
 ---
 
 ## Latest Major Release

--- a/pages/downloads.md
+++ b/pages/downloads.md
@@ -1,0 +1,60 @@
+---
+layout: 01_page
+title: Download
+---
+
+## Latest Major Release
+
+The latest release is Mapnik v2.2.0.
+
+## Platforms
+
+### OS X
+
+The recommend install method on OS X is `homebrew`. If you are running `homebrew` simply do:
+
+    brew update && brew install mapnik
+
+We also provide a pre-built [OS X 64 bit package](http://mapnik.s3.amazonaws.com/dist/v2.2.0/mapnik-osx-v2.2.0.dmg) that will install into the same place (`/usr/local`) as homebrew.
+
+### iOS
+
+ * [3-way arch (i386/armv7/armv7s) SDK](http://mapnik.s3.amazonaws.com/dist/v2.2.0/mapnik-ios-v2.2.0.tar.bz2)
+ * [Setup instructions](https://gist.github.com/springmeyer/5710531)
+
+### Windows
+
+ * [Windows 32 bit Package](http://mapnik.s3.amazonaws.com/dist/v2.2.0/mapnik-win-v2.2.0.zip)
+ * [Windows 32 bit SDK](http://mapnik.s3.amazonaws.com/dist/v2.2.0/mapnik-win-sdk-v2.2.0.zip)
+ * [Setup instructions](https://gist.github.com/springmeyer/5651701)
+
+### Ubuntu
+
+ * [Ubuntu PPA](https://launchpad.net/~mapnik/+archive/v2.2.0) ([more info](https://github.com/mapnik/mapnik/wiki/UbuntuInstallation))
+
+## Source
+
+To build Mapnik v2.2.0 from source either download the [v2.2.0 tarball](http://mapnik.s3.amazonaws.com/dist/v2.2.0/mapnik-v2.2.0.tar.bz2) or pull directly from github:
+
+    git clone https://github.com/mapnik/mapnik.git
+    git checkout v2.2.0
+
+For source install help see the [Install docs](https://github.com/mapnik/mapnik/blob/v2.2.0/INSTALL.md)
+
+You can also use git to fetch the latest code (will default to `master` branch):
+
+    git clone https://github.com/mapnik/mapnik.git
+
+Browse the code at [github](https://github.com/mapnik/mapnik).
+
+Download a snapshot as a [zip archive](https://github.com/mapnik/mapnik/archive/master.zip).
+
+##  Extra Installation Details
+
+See platform specific notes at [Mapnik Wiki](https://github.com/mapnik/mapnik/wiki/Mapnik-Installation).
+
+See also the detailed [Install guide](https://github.com/mapnik/mapnik/blob/master/INSTALL.md) for the development code.
+
+##  Older releases
+
+See the listing at [the download archive on s3](http://mapnik.s3.amazonaws.com/index.html?path=dist/).


### PR DESCRIPTION
@springmeyer @flippmoke @artemp - Add back Downloads page per https://github.com/mapnik/mapnik.github.com/issues/34, added to footer. 

![image](https://cloud.githubusercontent.com/assets/4587826/8219357/78921662-1517-11e5-867c-9eff5f109210.png).

