### PR TITLE
update XML example to include name="type", #48

### DIFF
--- a/_layouts/01_splash.html
+++ b/_layouts/01_splash.html
@@ -198,7 +198,8 @@ main() {
 	<Layer name="world" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
 		<StyleName>My Style</StyleName>
 		<Datasource>
-			<Parameter name="file">ne_110m_countries.shp</Parameter>
+			<Parameter name="file">path/to/shapefile.shp</Parameter>
+			<Parameter name="type">shape</Parameter>
 		</Datasource>
 	</Layer>
 </Map>


### PR DESCRIPTION
Updating the XML example on mapnik.org to include `name="type"` requirement. Fixes #48 

<img width="1016" alt="screen shot 2016-01-22 at 10 40 56 am" src="https://cloud.githubusercontent.com/assets/1943001/12519630/be72d37c-c0f4-11e5-984b-e2419e4fa7fa.png">

My only uncertainty is the change from a NED file type to something more generic `path/to/shapefile.shp`, in order to prevent someone feeling the need to download from Natural Earth Data. Some thoughts from @artemp or @springmeyer would be helpful, otherwise this is ready to go!