### PR TITLE
Use https for jquery and google fonts

### DIFF
--- a/_includes/mapnik.meta
+++ b/_includes/mapnik.meta
@@ -10,9 +10,9 @@
 <link href="/css/mapnik.css" rel="stylesheet" type="text/css" media="screen" />
 <link rel="alternate" type="application/atom+xml" href="atom.xml" title="Mapnik project news"/>
 <link rel="shortcut icon" href="/images/favicon.ico" />
-<link href='http://fonts.googleapis.com/css?family=Maven+Pro&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
+<link href='https://fonts.googleapis.com/css?family=Maven+Pro&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
 
-<script src='http://code.jquery.com/jquery-2.1.4.js'></script>
+<script src='https://code.jquery.com/jquery-2.1.4.js'></script>
 <script src='/js/mapnik.js'></script>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
 <script src="/js/parallax.js"></script>


### PR DESCRIPTION
Since jquery is being loaded properly users cant toggle between Python, Node and C++ on the start page